### PR TITLE
Align ProcessQueue default concurrency to 2

### DIFF
--- a/src/components/ImagePreview.tsx
+++ b/src/components/ImagePreview.tsx
@@ -6,8 +6,8 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { ImageFile, ConversionFormat, downloadImage } from "@/services/imageService";
-import { formatFileSize, formatDimensions } from "@/utils/formatUtils";
 import { cn } from "@/utils/css";
+import { formatFileSize, formatDimensions } from "@/utils/formatUtils";
 
 interface ImagePreviewProps {
   readonly file: ImageFile;

--- a/src/services/queueService.ts
+++ b/src/services/queueService.ts
@@ -13,7 +13,7 @@ export class ProcessQueue<R> {
   private processing = 0;
   private readonly maxConcurrent: number;
 
-  constructor(maxConcurrent = 3) {
+  constructor(maxConcurrent = 2) {
     this.maxConcurrent = maxConcurrent;
   }
 
@@ -97,8 +97,8 @@ export class ProcessQueue<R> {
 }
 
 /**
- * Create an image processing queue with a limit of maxConcurrent concurrent operations
- * @param maxConcurrent Maximum number of concurrent operations (default: 2)
+ * Create an image processing queue with a limit of maxConcurrent concurrent operations.
+ * @param maxConcurrent Maximum number of concurrent operations (defaults to 2)
  */
 export const createImageProcessingQueue = <R>(maxConcurrent = 2) => {
   return new ProcessQueue<R>(maxConcurrent);


### PR DESCRIPTION
## Summary
- default ProcessQueue to 2 concurrent tasks
- clarify `createImageProcessingQueue` docs to match default
- reorder `ImagePreview` imports to satisfy lint

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aae28be8b08328a8cffe578a205a05