### PR TITLE
Revoke object URLs after image download and size checks

### DIFF
--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -97,15 +97,18 @@ export const downloadImage = (blob: Blob, filename: string, format: ConversionFo
   link.download = `${filename.split(".")[0]}.${format}`;
   document.body.appendChild(link);
   link.click();
+  URL.revokeObjectURL(link.href);
   document.body.removeChild(link);
 };
 
 export const getImageSize = async (file: Blob) => {
   const img = new Image();
-  img.src = URL.createObjectURL(file);
+  const objectUrl = URL.createObjectURL(file);
+  img.src = objectUrl;
   await new Promise((resolve) => {
     img.onload = resolve;
   });
 
+  URL.revokeObjectURL(objectUrl);
   return { width: img.width, height: img.height };
 };


### PR DESCRIPTION
## Summary
- Revoke object URL after triggering image downloads
- Clean up object URLs after calculating image dimensions

## Testing
- `yarn lint` *(fails: `ImagePreview.tsx` import order)*
- `yarn eslint src/services/imageService.ts`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68aae283148c832897bde2f16ce87e97