### PR TITLE
feat: clarify resize inputs

### DIFF
--- a/src/pages/BackgroundRemover.tsx
+++ b/src/pages/BackgroundRemover.tsx
@@ -240,7 +240,7 @@ export default function BackgroundRemover() {
                     <div className="flex items-center gap-2">
                       <Input
                         type="number"
-                        placeholder="Width (leave blank to auto-calc height)"
+                        placeholder="Width"
                         value={resizeOptions.width || ""}
                         onChange={handleWidthChange}
                         className="w-28"
@@ -249,15 +249,16 @@ export default function BackgroundRemover() {
                       <span className="text-muted-foreground">or</span>
                       <Input
                         type="number"
-                        placeholder="Height (leave blank to auto-calc width)"
+                        placeholder="Height"
                         value={resizeOptions.height || ""}
                         onChange={handleHeightChange}
                         className="w-28"
                         disabled={!!resizeOptions.width}
                       />
                     </div>
-                    <p className="text-xs text-muted-foreground">
-                      Enter either width or height; the other dimension will be calculated automatically to maintain aspect ratio.
+                    <p className="text-muted-foreground text-xs">
+                      Enter <strong>either width or height</strong>. The other dimension will be
+                      calculated automatically to maintain aspect ratio.
                     </p>
                   </div>
                 )}

--- a/src/pages/BackgroundRemover.tsx
+++ b/src/pages/BackgroundRemover.tsx
@@ -236,22 +236,29 @@ export default function BackgroundRemover() {
                   </label>
                 </div>
                 {enableResize && (
-                  <div className="flex items-center gap-2">
-                    <Input
-                      type="number"
-                      placeholder="Width"
-                      value={resizeOptions.width || ""}
-                      onChange={handleWidthChange}
-                      className="w-28"
-                    />
-                    <span className="text-muted-foreground">or</span>
-                    <Input
-                      type="number"
-                      placeholder="Height"
-                      value={resizeOptions.height || ""}
-                      onChange={handleHeightChange}
-                      className="w-28"
-                    />
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="number"
+                        placeholder="Width (leave blank to auto-calc height)"
+                        value={resizeOptions.width || ""}
+                        onChange={handleWidthChange}
+                        className="w-28"
+                        disabled={!!resizeOptions.height}
+                      />
+                      <span className="text-muted-foreground">or</span>
+                      <Input
+                        type="number"
+                        placeholder="Height (leave blank to auto-calc width)"
+                        value={resizeOptions.height || ""}
+                        onChange={handleHeightChange}
+                        className="w-28"
+                        disabled={!!resizeOptions.width}
+                      />
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Enter either width or height; the other dimension will be calculated automatically to maintain aspect ratio.
+                    </p>
                   </div>
                 )}
               </div>

--- a/src/pages/ImageConverter.tsx
+++ b/src/pages/ImageConverter.tsx
@@ -246,22 +246,29 @@ export default function ImageConverter() {
                   </label>
                 </div>
                 {enableResize && (
-                  <div className="flex items-center gap-2">
-                    <Input
-                      type="number"
-                      placeholder="Width"
-                      value={resizeOptions.width || ""}
-                      onChange={handleWidthChange}
-                      className="w-28"
-                    />
-                    <span className="text-muted-foreground">or</span>
-                    <Input
-                      type="number"
-                      placeholder="Height"
-                      value={resizeOptions.height || ""}
-                      onChange={handleHeightChange}
-                      className="w-28"
-                    />
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="number"
+                        placeholder="Width (leave blank to auto-calc height)"
+                        value={resizeOptions.width || ""}
+                        onChange={handleWidthChange}
+                        className="w-28"
+                        disabled={!!resizeOptions.height}
+                      />
+                      <span className="text-muted-foreground">or</span>
+                      <Input
+                        type="number"
+                        placeholder="Height (leave blank to auto-calc width)"
+                        value={resizeOptions.height || ""}
+                        onChange={handleHeightChange}
+                        className="w-28"
+                        disabled={!!resizeOptions.width}
+                      />
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Enter either width or height; the other dimension will be calculated automatically to maintain aspect ratio.
+                    </p>
                   </div>
                 )}
               </div>

--- a/src/pages/ImageConverter.tsx
+++ b/src/pages/ImageConverter.tsx
@@ -213,6 +213,9 @@ export default function ImageConverter() {
                     <SelectItem value="tiff">TIFF</SelectItem>
                   </SelectContent>
                 </Select>
+                <p className="text-muted-foreground text-xs">
+                  {formatRecommendations[format].description}
+                </p>
               </div>
 
               <div className="space-y-2">
@@ -266,7 +269,7 @@ export default function ImageConverter() {
                         disabled={!!resizeOptions.width}
                       />
                     </div>
-                    <p className="text-muted-foreground text-xs">
+                    <p className="text-muted-foreground max-w-100 text-xs">
                       Enter <strong>either width or height</strong>. The other dimension will be
                       calculated automatically to maintain aspect ratio.
                     </p>
@@ -274,10 +277,6 @@ export default function ImageConverter() {
                 )}
               </div>
             </div>
-
-            <p className="text-muted-foreground text-xs">
-              {formatRecommendations[format].description}
-            </p>
           </div>
 
           <div className="flex flex-col gap-4">

--- a/src/pages/ImageConverter.tsx
+++ b/src/pages/ImageConverter.tsx
@@ -250,7 +250,7 @@ export default function ImageConverter() {
                     <div className="flex items-center gap-2">
                       <Input
                         type="number"
-                        placeholder="Width (leave blank to auto-calc height)"
+                        placeholder="Width"
                         value={resizeOptions.width || ""}
                         onChange={handleWidthChange}
                         className="w-28"
@@ -259,15 +259,16 @@ export default function ImageConverter() {
                       <span className="text-muted-foreground">or</span>
                       <Input
                         type="number"
-                        placeholder="Height (leave blank to auto-calc width)"
+                        placeholder="Height"
                         value={resizeOptions.height || ""}
                         onChange={handleHeightChange}
                         className="w-28"
                         disabled={!!resizeOptions.width}
                       />
                     </div>
-                    <p className="text-xs text-muted-foreground">
-                      Enter either width or height; the other dimension will be calculated automatically to maintain aspect ratio.
+                    <p className="text-muted-foreground text-xs">
+                      Enter <strong>either width or height</strong>. The other dimension will be
+                      calculated automatically to maintain aspect ratio.
                     </p>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- clarify width and height placeholders in resize controls
- add hint and disable opposite dimension input in ImageConverter and BackgroundRemover

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aae5b779c88328b457320edb8131ca